### PR TITLE
remove tmpfile cleanup for issue files

### DIFF
--- a/usr/lib/tmpfiles.d/console-login-helper-messages.conf
+++ b/usr/lib/tmpfiles.d/console-login-helper-messages.conf
@@ -1,1 +1,0 @@
-d /run/console-login-helper-messages - - - - -


### PR DESCRIPTION
Follow-up for https://github.com/coreos/console-login-helper-messages/pull/130 where we moved to writing the issues to `/run`. There is no need to cleanup after ourselves here as `/run` will be emptied at shutdown anyway.