### PR TITLE
tests/test-profile: Don't install dependencies (not needed)

### DIFF
--- a/tests/kola/basic/test-profile.sh
+++ b/tests/kola/basic/test-profile.sh
@@ -8,8 +8,6 @@ set -xeuo pipefail
 
 . ${KOLA_EXT_DATA}/test-util.sh
 
-install_dependencies
-
 # Add a systemd unit that will fail
 cat > /etc/systemd/system/${PKG_NAME}-fail-unit-test.service <<EOF
 [Unit]


### PR DESCRIPTION
See: https://github.com/coreos/console-login-helper-messages/pull/130