### PR TITLE
Revert "remove tmpfile cleanup for issue files in `/run`"

### DIFF
--- a/tests/kola/basic/test-motd.sh
+++ b/tests/kola/basic/test-motd.sh
@@ -28,8 +28,14 @@ cat my.key.pub >> ~/.ssh/authorized_keys
 # Check that a new motd snippet will be displayed at login from SSH when a .motd
 # file is dropped into the MOTD run directory.
 echo 'foo' > "${MOTD_RUN_SNIPPETS_PATH}/10_foo.motd"
-( timeout 5 script -c "ssh -tt -o StrictHostKeyChecking=no -i my.key root@localhost" ssh_login_output.txt ) || :
-assert_file_has_content ssh_login_output.txt '^foo'
+# Wait until SSH is ready to accept connections
+for i in $(seq 1 10); do
+    ssh -o StrictHostKeyChecking=no -o ConnectTimeout=1 -i my.key root@localhost true 2>/dev/null && break
+    sleep 1
+done
+
+( timeout 5 script -c "ssh -tt -o StrictHostKeyChecking=no -i my.key root@localhost" ssh_login_output.txt ) || true
+assert_file_has_content ssh_login_output.txt 'foo'
 ok "display new MOTD"
 
 tap_finish

--- a/usr/lib/tmpfiles.d/console-login-helper-messages-issuegen.conf
+++ b/usr/lib/tmpfiles.d/console-login-helper-messages-issuegen.conf
@@ -1,1 +1,0 @@
-r /run/issue.d/*_clhm_*.issue - - - - -

--- a/usr/lib/tmpfiles.d/console-login-helper-messages.conf
+++ b/usr/lib/tmpfiles.d/console-login-helper-messages.conf
@@ -1,0 +1,1 @@
+d /run/console-login-helper-messages - - - - -


### PR DESCRIPTION
This reverts commit 2db33c1b45061e549d76fd6febe972fb4d83e1b7 which deleted the wrong tpmfile config.

This directory is required in [1]

[1] https://github.com/coreos/console-login-helper-messages/blob/4c66bbb9c69731d87f56db77fb6cc796df68570d/usr/lib/console-login-helper-messages/libutil.sh#L35-L41