### PR TITLE
libutil: create tempfile_dir before mktemp

### DIFF
--- a/usr/lib/console-login-helper-messages/libutil.sh
+++ b/usr/lib/console-login-helper-messages/libutil.sh
@@ -32,6 +32,7 @@ restorecon=$(command -v restorecon || echo "true")
 # generated file path, this avoids interleaving writes to the generated
 # file by using `mv` to overwrite the file.
 write_via_tempfile() {
+    mkdir -p "${tempfile_dir}"
     local generated_file="$1"
     local staged_file="$(mktemp --tmpdir="${tempfile_dir}" "${tempfile_template}")"
     cat > "${staged_file}"

--- a/usr/lib/console-login-helper-messages/libutil.sh
+++ b/usr/lib/console-login-helper-messages/libutil.sh
@@ -41,22 +41,3 @@ write_via_tempfile() {
     ${restorecon} "${generated_file}"
 }
 
-# Write concatenation of all files with a given suffix from a list of
-# source directories to a target file. The target file is the first
-# argument; suffix the second; and source directories the remaining,
-# searched in the given order in the list. Atomicity of the write to
-# the target file is given by appending file contents to a tempfile
-# before moving to the target file.
-cat_via_tempfile() {
-    local generated_file="$1"
-    local filter_suffix="$2"
-    shift 2
-    local staged_file="$(mktemp --tmpdir="${tempfile_dir}" "${tempfile_template}")"
-    for source_dir in "${@}"; do
-        # Ignore stderr, and let the command succeed if no files are
-        # found in the source directory.
-        cat "${source_dir}"/*"$filter_suffix" 2>/dev/null >> "${staged_file}" || :
-    done
-    mv "${staged_file}" "${generated_file}"
-    ${restorecon} "${generated_file}"
-}


### PR DESCRIPTION
Ensure the temporary directory exists before calling `mktemp`.

```
$ journalctl -u console-login-helper-messages-gensnippet-ssh-keys.service
Jul 22 10:40:53 qemu0 systemd[1]: Starting console-login-helper-messages-gensnippet-ssh-keys.service - Generate SSH keys snippet for display via console-login-helper-messages...
Jul 22 10:40:53 qemu0 gensnippet_ssh_keys[1480]: mktemp: failed to create file via template ‘/run/console-login-helper-messages/console-login-helper-messages.XXXXXXXXXX.tmp’: No such file or directory
```